### PR TITLE
Make it clearer that 'memoize' is a namedExports

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ namedExports: {
   underscore: [
     'omit',
     'debounce',
+    'memoize'
   ],
   'lib/utils': [
     'escape',


### PR DESCRIPTION
Even though that feature is deprecated, as long as it documented
it might be clearer to see that `memoize` was defined in `namedExports`
before we use it on the line below (`import { memoize } from 'underscore';`)